### PR TITLE
[염정운] 대시보드 데이터 바인딩

### DIFF
--- a/src/main/java/com/aesopwow/subsubclipclop/controller/AnalysisController.java
+++ b/src/main/java/com/aesopwow/subsubclipclop/controller/AnalysisController.java
@@ -23,6 +23,11 @@ public class AnalysisController {
             @RequestParam String infoDbNo,
             @RequestParam String originTable) {
 
+        // 파라미터 유효성 검사
+        if (infoDbNo == null || infoDbNo.isBlank() || originTable == null || originTable.isBlank()) {
+            throw new IllegalArgumentException("필수 파라미터가 누락되었습니다.");
+        }
+
         byte[] fileBytes = apiService.getAnalysisResult(infoDbNo, originTable);
 
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/aesopwow/subsubclipclop/controller/AnalysisController.java
+++ b/src/main/java/com/aesopwow/subsubclipclop/controller/AnalysisController.java
@@ -20,14 +20,16 @@ public class AnalysisController {
 
     @GetMapping("")
     public ResponseEntity<byte[]> getAnalysisResult(
-            @RequestParam String filename) {
-        byte[] fileBytes = apiService.getAnalysisResult(filename);
+            @RequestParam String infoDbNo,
+            @RequestParam String originTable) {
+
+        byte[] fileBytes = apiService.getAnalysisResult(infoDbNo, originTable);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
         headers.setContentDisposition(ContentDisposition
                 .attachment()
-                .filename(filename)
+                .filename("dashboard_" + infoDbNo + ".csv") // ✅ 파일 이름 명시
                 .build());
 
         return new ResponseEntity<>(fileBytes, headers, HttpStatus.OK);

--- a/src/main/java/com/aesopwow/subsubclipclop/controller/DashBoardController.java
+++ b/src/main/java/com/aesopwow/subsubclipclop/controller/DashBoardController.java
@@ -3,6 +3,8 @@ package com.aesopwow.subsubclipclop.controller;
 import com.aesopwow.subsubclipclop.domain.api.dto.ApiResponseDto;
 import com.aesopwow.subsubclipclop.domain.api.service.ApiService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,5 +27,18 @@ public class DashBoardController {
         ApiResponseDto apiResponseDto = new ApiResponseDto(statCardCSV);
 
         return ResponseEntity.ok(apiResponseDto);
+    }
+
+    @GetMapping("/{infoDbNo}/{originTable}")
+    public ResponseEntity<byte[]> getDashBoardCSV2(
+            @PathVariable String infoDbNo,
+            @PathVariable String originTable) {
+
+        byte[] csvBytes = apiService.getAnalysisResult2(infoDbNo, originTable);
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.valueOf("text/csv"))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"dashboard.csv\"")
+                .body(csvBytes);
     }
 }

--- a/src/main/java/com/aesopwow/subsubclipclop/controller/DashBoardController.java
+++ b/src/main/java/com/aesopwow/subsubclipclop/controller/DashBoardController.java
@@ -18,23 +18,23 @@ import org.springframework.web.bind.annotation.RestController;
 public class DashBoardController {
     private final ApiService apiService;
 
-    @ExceptionHandler
-    @GetMapping("/{infoDbNo}")
-    public ResponseEntity<ApiResponseDto> getDashBoardCSV(
-            @PathVariable(required = true) String infoDbNo) {
-
-        byte[] statCardCSV = apiService.getAnalysisResult(infoDbNo);
-        ApiResponseDto apiResponseDto = new ApiResponseDto(statCardCSV);
-
-        return ResponseEntity.ok(apiResponseDto);
-    }
+//    @ExceptionHandler
+//    @GetMapping("/{infoDbNo}")
+//    public ResponseEntity<ApiResponseDto> getDashBoardCSV(
+//            @PathVariable(required = true) String infoDbNo) {
+//
+//        byte[] statCardCSV = apiService.getAnalysisResult(infoDbNo);
+//        ApiResponseDto apiResponseDto = new ApiResponseDto(statCardCSV);
+//
+//        return ResponseEntity.ok(apiResponseDto);
+//    }
 
     @GetMapping("/{infoDbNo}/{originTable}")
-    public ResponseEntity<byte[]> getDashBoardCSV2(
+    public ResponseEntity<byte[]> getDashBoardCSV(
             @PathVariable String infoDbNo,
             @PathVariable String originTable) {
 
-        byte[] csvBytes = apiService.getAnalysisResult2(infoDbNo, originTable);
+        byte[] csvBytes = apiService.getAnalysisResult(infoDbNo, originTable);
 
         return ResponseEntity.ok()
                 .contentType(MediaType.valueOf("text/csv"))

--- a/src/main/java/com/aesopwow/subsubclipclop/domain/api/service/ApiService.java
+++ b/src/main/java/com/aesopwow/subsubclipclop/domain/api/service/ApiService.java
@@ -14,4 +14,6 @@ public interface ApiService {
     public ApiResponseDto requestAnalysis(ApiRequestDto apiRequestDto);
 
     public byte[] getAnalysisResult(String filename);
+
+    public byte[] getAnalysisResult2(String infoDbNo, String originTable);
 }

--- a/src/main/java/com/aesopwow/subsubclipclop/domain/api/service/ApiService.java
+++ b/src/main/java/com/aesopwow/subsubclipclop/domain/api/service/ApiService.java
@@ -13,7 +13,7 @@ public interface ApiService {
 
     public ApiResponseDto requestAnalysis(ApiRequestDto apiRequestDto);
 
-    public byte[] getAnalysisResult(String filename);
+//    public byte[] getAnalysisResult(String filename);
 
-    public byte[] getAnalysisResult2(String infoDbNo, String originTable);
+    public byte[] getAnalysisResult(String infoDbNo, String originTable);
 }

--- a/src/main/java/com/aesopwow/subsubclipclop/domain/api/service/ApiServiceImpl.java
+++ b/src/main/java/com/aesopwow/subsubclipclop/domain/api/service/ApiServiceImpl.java
@@ -73,8 +73,15 @@ public class ApiServiceImpl implements ApiService {
 //                .block(); // 동기 방식으로 대기
 //    }
 
+    private static final int DASHBOARD_API_TIMEOUT_SECONDS = 10;
+    
     @Override
     public byte[] getAnalysisResult(String infoDbNo, String originTable) {
+
+        if (infoDbNo == null || infoDbNo.isBlank() || originTable == null || originTable.isBlank()) {
+            throw new IllegalArgumentException("필수 파라미터가 누락되었습니다.");
+        }
+
         try {
             return webClient.get()
                     .uri(uriBuilder -> uriBuilder
@@ -86,8 +93,8 @@ public class ApiServiceImpl implements ApiService {
                     .accept(MediaType.APPLICATION_OCTET_STREAM)
                     .retrieve()
                     .bodyToMono(byte[].class)
-                    .timeout(Duration.ofSeconds(10)) // 타임아웃 설정
-                    .block(); // 동기 방식으로 대기
+                    .timeout(Duration.ofSeconds(DASHBOARD_API_TIMEOUT_SECONDS))
+                    .block();
         } catch (WebClientResponseException e) {
             log.error("대시보드 데이터 요청 실패: {}, 상태 코드: {}", e.getMessage(), e.getStatusCode());
             throw new CustomException(ErrorCode.DASHBOARD_API_FAILED, e);

--- a/src/main/java/com/aesopwow/subsubclipclop/domain/api/service/ApiServiceImpl.java
+++ b/src/main/java/com/aesopwow/subsubclipclop/domain/api/service/ApiServiceImpl.java
@@ -3,17 +3,25 @@ package com.aesopwow.subsubclipclop.domain.api.service;
 import com.aesopwow.subsubclipclop.domain.api.dto.ApiRequestDto;
 import com.aesopwow.subsubclipclop.domain.api.dto.ApiResponseDto;
 import com.aesopwow.subsubclipclop.domain.info_column.dto.InfoColumnResponseDto;
+import com.aesopwow.subsubclipclop.global.enums.ErrorCode;
+import com.aesopwow.subsubclipclop.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
+import java.time.Duration;
 import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Service
 @RequiredArgsConstructor
 public class ApiServiceImpl implements ApiService {
     private final WebClient webClient = WebClient.create("http://127.0.0.1:5000");
+    private static final Logger log = LoggerFactory.getLogger(ApiServiceImpl.class);
 
     @Override
     public String callExternalApi(Long companyNo) {
@@ -41,20 +49,6 @@ public class ApiServiceImpl implements ApiService {
     }
 
     @Override
-    public byte[] getAnalysisResult(String filename) {
-        return webClient.get()
-                .uri(uriBuilder -> uriBuilder
-                        .path("/python-api/analysis")
-                        .queryParam("file_name", filename)
-                        .build()
-                )
-                .accept(MediaType.APPLICATION_OCTET_STREAM)
-                .retrieve()
-                .bodyToMono(byte[].class)
-                .block(); // 동기 방식으로 대기
-    }
-
-    @Override
     public ApiResponseDto requestAnalysis(ApiRequestDto apiRequestDto) {
         return webClient.post()
                 .uri("/python-api/analysis")
@@ -65,18 +59,41 @@ public class ApiServiceImpl implements ApiService {
                 .block();
     }
 
+//    @Override
+//    public byte[] getAnalysisResult(String filename) {
+//        return webClient.get()
+//                .uri(uriBuilder -> uriBuilder
+//                        .path("/python-api/analysis")
+//                        .queryParam("file_name", filename)
+//                        .build()
+//                )
+//                .accept(MediaType.APPLICATION_OCTET_STREAM)
+//                .retrieve()
+//                .bodyToMono(byte[].class)
+//                .block(); // 동기 방식으로 대기
+//    }
+
     @Override
-    public byte[] getAnalysisResult2(String infoDbNo, String originTable) {
-        return webClient.get()
-                .uri(uriBuilder -> uriBuilder
-                        .path("/python-api/dashboard")
-                        .queryParam("info_db_no", infoDbNo)
-                        .queryParam("origin_table", originTable)
-                        .build()
-                )
-                .accept(MediaType.APPLICATION_OCTET_STREAM)
-                .retrieve()
-                .bodyToMono(byte[].class)
-                .block(); // 동기 방식으로 대기
+    public byte[] getAnalysisResult(String infoDbNo, String originTable) {
+        try {
+            return webClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/python-api/dashboard")
+                            .queryParam("info_db_no", infoDbNo)
+                            .queryParam("origin_table", originTable)
+                            .build()
+                    )
+                    .accept(MediaType.APPLICATION_OCTET_STREAM)
+                    .retrieve()
+                    .bodyToMono(byte[].class)
+                    .timeout(Duration.ofSeconds(10)) // 타임아웃 설정
+                    .block(); // 동기 방식으로 대기
+        } catch (WebClientResponseException e) {
+            log.error("대시보드 데이터 요청 실패: {}, 상태 코드: {}", e.getMessage(), e.getStatusCode());
+            throw new CustomException(ErrorCode.DASHBOARD_API_FAILED, e);
+        } catch (Exception e) {
+            log.error("대시보드 데이터 요청 중 예외 발생: {}", e.getMessage());
+            throw new CustomException(ErrorCode.DASHBOARD_UNKNOWN_ERROR, e);
+        }
     }
 }

--- a/src/main/java/com/aesopwow/subsubclipclop/domain/api/service/ApiServiceImpl.java
+++ b/src/main/java/com/aesopwow/subsubclipclop/domain/api/service/ApiServiceImpl.java
@@ -65,4 +65,18 @@ public class ApiServiceImpl implements ApiService {
                 .block();
     }
 
+    @Override
+    public byte[] getAnalysisResult2(String infoDbNo, String originTable) {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/python-api/dashboard")
+                        .queryParam("info_db_no", infoDbNo)
+                        .queryParam("origin_table", originTable)
+                        .build()
+                )
+                .accept(MediaType.APPLICATION_OCTET_STREAM)
+                .retrieve()
+                .bodyToMono(byte[].class)
+                .block(); // 동기 방식으로 대기
+    }
 }

--- a/src/main/java/com/aesopwow/subsubclipclop/global/enums/ErrorCode.java
+++ b/src/main/java/com/aesopwow/subsubclipclop/global/enums/ErrorCode.java
@@ -32,7 +32,9 @@ public enum ErrorCode {
     //MARK: - Forbidden
     ONLY_CLIENT_USER_DELETABLE("E019", "직원만 삭제할 수 있습니다.", HttpStatus.FORBIDDEN),
     ONLY_CLIENT_ADMIN_ALLOWED("E020", "관리자 권한이 있어야 수행할 수 있습니다.", HttpStatus.FORBIDDEN),
-
+    //MARK: - Dashboard
+    DASHBOARD_API_FAILED("E030", "대시보드 데이터를 가져오는 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR),
+    DASHBOARD_UNKNOWN_ERROR("E031", "대시보드 데이터를 가져오는 중 알 수 없는 예외 발생", HttpStatus.INTERNAL_SERVER_ERROR),
     //MARK: -
     ACCESS_TOKEN_INVALID("E900","유효하지 않은 토큰 값입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 


### PR DESCRIPTION
대시 보드에 대한 데이터 바인딩을 진행했습니다. 실제로 python서버로 요청한는 것을 가정 했으며, 따로 테이블을 만들어서 확인 작업 까지 끝냈습니다. 다만 netflix_users.csv에 created_at이 없고 python 서버는 created_at 컬럼을 요구 하도록 설정 되어있기 때문에 이 부분은 추후에 수정을 해야할 듯 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 대시보드 CSV 데이터를 파일로 다운로드할 수 있는 새로운 API 엔드포인트가 추가되었습니다.  
  - 파일 다운로드 시 "dashboard.csv" 또는 "dashboard_{infoDbNo}.csv" 이름으로 저장됩니다.  
  - 대시보드 데이터 요청 시 오류 발생에 대한 새로운 에러 코드가 추가되어 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->