### PR TITLE
[염정운] 알림 CORS 에러 방지 해결을 위한 SecurityConfig 수정

### DIFF
--- a/src/main/java/com/aesopwow/subsubclipclop/config/SecurityConfig.java
+++ b/src/main/java/com/aesopwow/subsubclipclop/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -57,12 +58,15 @@ public class SecurityConfig {
         return http.build();
     }
 
+    @Value("${cors.allowed-origins}") // ✅ WebConfig와 동일한 값 주입
+    private String allowedOrigins;
+
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("https://dagudok-service.com", "http://localhost:5173", "http://127.0.0.1:3000", "https://api.dagudok-service.com"));
+        config.setAllowedOrigins(List.of(allowedOrigins, "http://127.0.0.1:3000","https://dagudok-service.com", "http://localhost:5173", "http://127.0.0.1:3000", "https://api.dagudok-service.com"));
 //        config.setAllowedOrigins(List.of("*"));
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
 


### PR DESCRIPTION
알림 기능 구현 중 SecurityConfig가 WebConfig의 내용을 가려서 CORS 문제가 발생하는 것을 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - CORS 설정에서 허용되는 오리진을 외부 설정에서 주입받아 동적으로 관리할 수 있도록 개선되었습니다.
- **기능 개선**
  - CORS에서 허용되는 HTTP 메서드에 "PATCH"가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->